### PR TITLE
Пользователи в БД теперь сеются с правильными ролями. (Решение бага.)

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -40,6 +40,7 @@ class UserController extends Controller
     public function signup(SignupRequest $request)
     {
         $user = User::create($request->all());
+        $user->setRole('user');
 
         return [
             'data' => [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,14 +35,6 @@ class User extends Authenticatable
         'password',
     ];
 
-    protected static function boot()
-    {
-        parent::boot();
-        self::creating(function ($model) {
-            $model->setRole('user');
-        });
-    }
-
 
     public function generateToken()
     {


### PR DESCRIPTION
При посеве всем пользователям назначалась роль 'user', что было прописано в модели пользователей, метод boot. Данное действие было перенесено в контроллер пользователей, в действии signup.